### PR TITLE
READMEへのDB設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,45 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+
+# Chat-space DB 設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|username|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+### Association
+- has_many :comments
+- has_many :users_groups
+- has_many  :groups,  through:  :users_groups
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+### Association
+- has_many :comments
+- has_many :users_groups
+- has_many  :users,  through:  :users_groups
+
+## users_groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## commentsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|body|text|null: false|
+|image|string||
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+- belongs_to :group

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Things you may want to cover:
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|username|string|null: false|
+|name|string|null: false|
 |email|string|null: false|
 |password|string|null: false|
 ### Association
@@ -39,7 +39,7 @@ Things you may want to cover:
 ## groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|group_name|string|null: false|
+|name|string|null: false|
 ### Association
 - has_many :comments
 - has_many :users_groups
@@ -48,8 +48,8 @@ Things you may want to cover:
 ## users_groupsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|reference|null: false, foreign_key: true|
+|group|reference|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group
@@ -59,8 +59,8 @@ Things you may want to cover:
 |------|----|-------|
 |body|text|null: false|
 |image|string||
-|user_id|integer|null: false, foreign_key: true|
-|group_id|integer|null: false, foreign_key: true|
+|user|reference|null: false, foreign_key: true|
+|group|reference|null: false, foreign_key: true|
 ### Association
 - belongs_to :user
 - belongs_to :group


### PR DESCRIPTION
# What
Chat-spaceに必要なDB設計をREADMEに記載した。
userテーブル、groupテーブル、commentテーブルについて記載した。
それぞれ
<dl>
  <dt>usersテーブル</dt>
    <dd>usernameカラム、emailカラム、passwordカラムを持つ</dd>
<dt>groupsテーブル</dt>
    <dd>groupnameカラムを持つ</dd>
<dt>users_groupsテーブル</dt>
    <dd>user_idカラム、group_idカラムを持つ中間テーブル</dd>
<dt>commentsテーブル</dt>
    <dd>bodyカラム、imageカラム、user_idカラム、group_idカラムを持つ</dd>
</dl>

# Why
Chat-spaceの主要なデータベースの設計をしておく必要があるため